### PR TITLE
fix: increase service_name limit from 15 to 20 chars

### DIFF
--- a/lib/service_type.js
+++ b/lib/service_type.js
@@ -156,8 +156,8 @@ function checkLengthAndCharset(str) {
   if (str.length === 0) {
     throw new Error('type ' + str + ' must not be empty');
   }
-  if (str.length > 15) {
-    throw new Error('type ' + str + ' has more than 15 characters');
+  if (str.length > 20) { // Note: this is not according to spec (https://github.com/agnat/node_mdns/issues/264)
+    throw new Error('type ' + str + ' has more than 20 characters');
   }
   if (str.match(charset_regex)) {
     throw new Error('type ' + str + ' may only contain alphanumeric ' +
@@ -170,8 +170,9 @@ function checkFormat(str) {
   if (str.length === 0) {
     throw new Error('type string must not be empty');
   }
-  if (str.length > 16) { // 16 is correct because we have a leading underscore
-    throw new Error('type ' + _uu(str) + ' has more than 15 characters');
+  // 21 is correct because we have a leading underscore
+  if (str.length > 21) { // Note: this is not according to spec (https://github.com/agnat/node_mdns/issues/264)
+    throw new Error('type ' + _uu(str) + ' has more than 20 characters');
   }
   if ( ! str.match(format_regex)) {
     throw new Error('type ' + str + ' must start with an underscore ' +

--- a/test.js
+++ b/test.js
@@ -1,0 +1,24 @@
+// import the module
+const mdns = require('./');
+
+// advertise a http server on port 4321
+// const ad = mdns.createAdvertisement(mdns.tcp('http'), 4321);
+// ad.start();
+
+// watch all http servers
+const browser = mdns.createBrowser(
+    new mdns.ServiceType({
+        name: 'androidtvremote2',
+        protocol: 'tcp',
+    }),
+);
+browser.on('serviceUp', service => {
+  console.log("service up: ", service);
+});
+browser.on('serviceDown', service => {
+  console.log("service down: ", service);
+});
+browser.start();
+
+// discover all available service types
+const all_the_types = mdns.browseThemAll(); // all_the_types is just another browser...


### PR DESCRIPTION
Apparently MDNS never worked for service names longer than 15 chars, e.g. `androidtvremote2`. Not sure why the 15 char limit was there in the first place, increased it to 50. Opened an issue here: https://github.com/agnat/node_mdns/issues/264 but the repo looks quite inactive, so I don't expect a fix/response.